### PR TITLE
add common logger interface

### DIFF
--- a/.rubocop_rspec.yml
+++ b/.rubocop_rspec.yml
@@ -9,3 +9,6 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Max: 8
+
+RSpec/MessageSpies:
+  EnforcedStyle: 'receive'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.0] - 2022-06-20
+- Added standard logger interface
+
 ## [1.1.2] - 2022-04-05
 - Fixed memory leak
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'rake'
 gem 'rspec'
 gem 'rubocop', require: false
 gem 'simplecov', require: false, group: :test
+gem 'logger'

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gemspec
 
 gem 'byebug'
 gem 'dotenv-rails'
+gem 'logger'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop', require: false
 gem 'simplecov', require: false, group: :test
-gem 'logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    google_logger (1.1.2)
+    google_logger (1.2.0)
       activesupport (>= 5.2.4.5)
+      logger (>= 1.5.1)
       stackdriver (>= 0.21.1)
 
 GEM
@@ -63,7 +64,7 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    gapic-common (0.8.0)
+    gapic-common (0.9.0)
       faraday (~> 1.3)
       google-protobuf (~> 3.14)
       googleapis-common-protos (>= 1.3.11, < 2.a)
@@ -92,7 +93,7 @@ GEM
     google-cloud-logging-v2 (0.7.0)
       gapic-common (>= 0.7, < 2.a)
       google-cloud-errors (~> 1.0)
-    google-cloud-trace (0.41.3)
+    google-cloud-trace (0.41.4)
       concurrent-ruby (~> 1.1)
       google-cloud-core (~> 1.5)
       google-cloud-trace-v1 (~> 0.0)
@@ -104,26 +105,27 @@ GEM
     google-cloud-trace-v2 (0.3.5)
       gapic-common (>= 0.7, < 2.a)
       google-cloud-errors (~> 1.0)
-    google-protobuf (3.20.0)
+    google-protobuf (3.20.0-x86_64-linux)
     googleapis-common-protos (1.3.12)
       google-protobuf (~> 3.14)
       googleapis-common-protos-types (~> 1.2)
       grpc (~> 1.27)
     googleapis-common-protos-types (1.3.0)
       google-protobuf (~> 3.14)
-    googleauth (1.1.2)
+    googleauth (1.1.3)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    grpc (1.45.0)
+    grpc (1.46.2-x86_64-linux)
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jwt (2.3.0)
+    logger (1.5.1)
     loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -217,6 +219,7 @@ DEPENDENCIES
   byebug
   dotenv-rails
   google_logger!
+  logger
   rake
   rspec
   rubocop

--- a/README.md
+++ b/README.md
@@ -59,7 +59,29 @@ config.project_id = 'another_project_id'
 
 ### Creating logs
 
-The simpest way to create logs is using the `GoogleLogger::create_entry` method.
+`GoogleLogger::JsonLogger` complies with the common Ruby `Logger` interface and it supports tagged logging as well, therefore you can use it separately or as a substitute for the default rails logger:
+
+```ruby
+require 'google_logger'
+
+# Standalone usage (default_log_name is optional)
+logger = ActiveSupport::TaggedLogging.new(default_log_name: 'default')
+# json
+logger.info({ message: 'structured log', array: [1, 2, 3] })
+# text
+logger.info('plain text')
+
+# Tagged logging as a substitute for the default rails logger
+Rails.application.configure do
+    config.logger = ActiveSupport::TaggedLogging.new(GoogleLogger::JsonLogger.new)
+end
+
+Rails.logger.tagged('my tag') do
+    Rails.logger.debug('"my tag" will be used as the logName for this log')
+end
+```
+
+It is also possible to create logs is using the `GoogleLogger::create_entry` method, which can be used directly without initializing a new instance of the `GoogleLogger::JsonLogger` class.
 
 ```ruby
 # logging a string
@@ -71,7 +93,7 @@ hash_payload = { some_text: 'log message', any_aray: [1, 2, 3], another_hash: { 
 GoogleLogger.create_entry(hash_payload)
 ```
 
-It is also possible to manually create the log entries:
+And if you need even more control, you can manually build and save the log entries:
 
 ```ruby
 logger = GoogleLogger.logger

--- a/google_logger.gemspec
+++ b/google_logger.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   # google cloud api
   spec.add_dependency 'activesupport', '>= 5.2.4.5'
-  spec.add_dependency 'stackdriver', '>= 0.21.1'
   spec.add_dependency 'logger', '>= 1.5.1'
+  spec.add_dependency 'stackdriver', '>= 0.21.1'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/google_logger.gemspec
+++ b/google_logger.gemspec
@@ -24,9 +24,10 @@ Gem::Specification.new do |spec|
 
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = %w[lib lib/google_logger lib/google_logger/loggers]
+  spec.require_paths = %w[lib lib/google_logger lib/google_logger/json_logger lib/google_logger/loggers]
 
   # google cloud api
   spec.add_dependency 'activesupport', '>= 5.2.4.5'
   spec.add_dependency 'stackdriver', '>= 0.21.1'
+  spec.add_dependency 'logger', '>= 1.5.1'
 end

--- a/lib/google_logger.rb
+++ b/lib/google_logger.rb
@@ -8,6 +8,7 @@ require 'google_logger/loggers/local_logger'
 require 'google_logger/loggers/base'
 require 'google_logger/controller_logging'
 require 'google_logger/params_replacer'
+require 'google_logger/json_logger'
 
 # Main module which should serve as an interface to all functionalities
 module GoogleLogger

--- a/lib/google_logger/json_logger.rb
+++ b/lib/google_logger/json_logger.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module GoogleLogger
+  class JsonLogger < ::Logger
+    SEVERITY_MAPPING = {
+      UNKNOWN => :DEFAULT,
+      FATAL => :CRITICAL,
+      ERROR => :ERROR,
+      WARN => :WARNING,
+      INFO => :INFO,
+      DEBUG => :DEBUG
+    }.freeze
+
+    def initialize(default_log_name: 'default')
+      @default_log_name = default_log_name
+      @tagged = nil
+      self.level = DEBUG
+    end
+
+    private
+
+    #
+    # @see Logger#add
+    #
+    def add(severity, message = nil, progname = nil)
+      return true if message.blank? && progname.blank?
+
+      severity ||= UNKNOWN
+      return true if severity < level
+
+      log_name = tagged? ? formatter.current_tags.join('.') : @default_log_name
+      GoogleLogger.create_entry(
+        message || progname,
+        log_name: log_name,
+        severity: SEVERITY_MAPPING.fetch(severity)
+      )
+    end
+
+    def tagged?
+      formatter.respond_to?(:current_tags) && formatter.current_tags.any?
+    end
+  end
+end

--- a/lib/google_logger/json_logger.rb
+++ b/lib/google_logger/json_logger.rb
@@ -30,6 +30,10 @@ module GoogleLogger
       severity ||= UNKNOWN
       return true if severity < level
 
+      create_formatted_log(severity, message, progname)
+    end
+
+    def create_formatted_log(severity, message = nil, progname = nil)
       log_name = tagged? ? formatter.current_tags.join('.') : @default_log_name
       GoogleLogger.create_entry(
         message || progname,

--- a/lib/google_logger/version.rb
+++ b/lib/google_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GoogleLogger
-  VERSION = '1.1.2'
+  VERSION = '1.2.0'
 end

--- a/spec/google_logger/json_logger_spec.rb
+++ b/spec/google_logger/json_logger_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe GoogleLogger::JsonLogger do
   let(:json_message) { { key: 'value' } }
   let(:tag_name) { 'my_tag' }
 
+  before do
+    allow(GoogleLogger).to receive(:create_entry)
+  end
+
   it 'logs a text message' do
     expect(GoogleLogger).to receive(:create_entry).with(message, log_name: 'default', severity: :INFO)
 
@@ -69,11 +73,7 @@ RSpec.describe GoogleLogger::JsonLogger do
         severity: :INFO
       )
 
-      logger.tagged(outer_tag) do
-        logger.tagged(tag_name) do
-          logger.info(message)
-        end
-      end
+      logger.tagged(outer_tag) { logger.tagged(tag_name) { logger.info(message) } }
     end
   end
 end

--- a/spec/google_logger/json_logger_spec.rb
+++ b/spec/google_logger/json_logger_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe GoogleLogger::JsonLogger do
+  let(:logger) { described_class.new }
+  let(:message) { 'log_message' }
+  let(:json_message) { { key: 'value' } }
+  let(:tag_name) { 'my_tag' }
+
+  it 'logs a text message' do
+    expect(GoogleLogger).to receive(:create_entry).with(message, log_name: 'default', severity: :INFO)
+
+    logger.info(message)
+  end
+
+  it 'logs a json message' do
+    expect(GoogleLogger).to receive(:create_entry).with(json_message, log_name: 'default', severity: :INFO)
+
+    logger.info(json_message)
+  end
+
+  context 'when setting severity' do
+    it 'creates a FATAL severity log' do
+      expect(GoogleLogger).to receive(:create_entry).with(message, log_name: 'default', severity: :CRITICAL)
+
+      logger.fatal(message)
+    end
+
+    it 'creates an ERROR severity log' do
+      expect(GoogleLogger).to receive(:create_entry).with(message, log_name: 'default', severity: :ERROR)
+
+      logger.error(message)
+    end
+
+    it 'creates a WARN severity log' do
+      expect(GoogleLogger).to receive(:create_entry).with(message, log_name: 'default', severity: :WARNING)
+
+      logger.warn(message)
+    end
+
+    it 'creates an INFO severity log' do
+      expect(GoogleLogger).to receive(:create_entry).with(message, log_name: 'default', severity: :INFO)
+
+      logger.info(message)
+    end
+
+    it 'creates a DEBUG severity log' do
+      expect(GoogleLogger).to receive(:create_entry).with(message, log_name: 'default', severity: :DEBUG)
+
+      logger.debug(message)
+    end
+  end
+
+  context 'when using tags' do
+    let(:logger) { ActiveSupport::TaggedLogging.new(described_class.new) }
+    let(:outer_tag) { 'outer_tag' }
+
+    it 'adds tags to the log' do
+      expect(GoogleLogger).to receive(:create_entry).with(message, log_name: tag_name, severity: :INFO)
+
+      logger.tagged(tag_name) do
+        logger.info(message)
+      end
+    end
+
+    it 'joins tag by "." when using multiple tags' do
+      expect(GoogleLogger).to receive(:create_entry).with(
+        message,
+        log_name: "#{outer_tag}.#{tag_name}",
+        severity: :INFO
+      )
+
+      logger.tagged(outer_tag) do
+        logger.tagged(tag_name) do
+          logger.info(message)
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/configuration_helper.rb
+++ b/spec/helpers/configuration_helper.rb
@@ -5,18 +5,18 @@ module ConfigurationHelper
     GoogleLogger.configuration = nil
 
     GoogleLogger.configure do |config|
-      config.project_id = ENV['GOOGLE_LOGGER_TEST_PROJECT_ID']
+      config.project_id = ENV.fetch('GOOGLE_LOGGER_TEST_PROJECT_ID', nil)
       config.credentials = {
-        type: ENV['GOOGLE_LOGGER_TEST_TYPE'],
-        project_id: ENV['GOOGLE_LOGGER_TEST_PROJECT_ID'],
-        private_key_id: ENV['GOOGLE_LOGGER_TEST_PRIVATE_KEY_ID'],
-        private_key: ENV['GOOGLE_LOGGER_TEST_PRIVATE_KEY'],
-        client_email: ENV['GOOGLE_LOGGER_TEST_CLIENT_EMAIL'],
-        client_id: ENV['GOOGLE_LOGGER_TEST_CLIENT_ID'],
-        auth_uri: ENV['GOOGLE_LOGGER_TEST_AUTH_URI'],
-        token_uri: ENV['GOOGLE_LOGGER_TEST_TOKEN_URI'],
-        auth_provider_x509_cert_url: ENV['GOOGLE_LOGGER_TEST_AUTH_PROVIDER_CERT_URL'],
-        client_x509_cert_url: ENV['GOOGLE_LOGGER_TEST_CLIENT_CERT_URL']
+        type: ENV.fetch('GOOGLE_LOGGER_TEST_TYPE', nil),
+        project_id: ENV.fetch('GOOGLE_LOGGER_TEST_PROJECT_ID', nil),
+        private_key_id: ENV.fetch('GOOGLE_LOGGER_TEST_PRIVATE_KEY_ID', nil),
+        private_key: ENV.fetch('GOOGLE_LOGGER_TEST_PRIVATE_KEY', nil),
+        client_email: ENV.fetch('GOOGLE_LOGGER_TEST_CLIENT_EMAIL', nil),
+        client_id: ENV.fetch('GOOGLE_LOGGER_TEST_CLIENT_ID', nil),
+        auth_uri: ENV.fetch('GOOGLE_LOGGER_TEST_AUTH_URI', nil),
+        token_uri: ENV.fetch('GOOGLE_LOGGER_TEST_TOKEN_URI', nil),
+        auth_provider_x509_cert_url: ENV.fetch('GOOGLE_LOGGER_TEST_AUTH_PROVIDER_CERT_URL', nil),
+        client_x509_cert_url: ENV.fetch('GOOGLE_LOGGER_TEST_CLIENT_CERT_URL', nil)
       }
       config.async = false
     end


### PR DESCRIPTION
Resolves #1 

added the common ruby logger interface, so that the logger can be used directly as a substitute for any logger